### PR TITLE
Feature/#9 UP0001 未完了フラグの更新処理

### DIFF
--- a/src/main/java/com/raisetech/mapper/TaskMapper.java
+++ b/src/main/java/com/raisetech/mapper/TaskMapper.java
@@ -22,7 +22,7 @@ public interface TaskMapper {
 	void insertTask(Task task);
 	
 	// 完了フラグを未完了から完了に更新
-	void updateTaskToComplete(int taskId);
+	void updateCompletedFlagToTrue(int taskId);
 
 	//タスクの一件削除
 	void deleteTask(int taskId);

--- a/src/main/java/com/raisetech/mapper/TaskMapper.java
+++ b/src/main/java/com/raisetech/mapper/TaskMapper.java
@@ -20,6 +20,9 @@ public interface TaskMapper {
 	
     //タスクの一件登録
 	void insertTask(Task task);
+	
+	// 完了フラグを未完了から完了に更新
+	void updateToCompletedFlag(int taskId);
 
 	//タスクの一件削除
 	void deleteTask(int taskId);

--- a/src/main/java/com/raisetech/mapper/TaskMapper.java
+++ b/src/main/java/com/raisetech/mapper/TaskMapper.java
@@ -22,7 +22,7 @@ public interface TaskMapper {
 	void insertTask(Task task);
 	
 	// 完了フラグを未完了から完了に更新
-	void updateToCompletedFlag(int taskId);
+	void updateTaskToComplete(int taskId);
 
 	//タスクの一件削除
 	void deleteTask(int taskId);

--- a/src/main/java/com/raisetech/service/TaskService.java
+++ b/src/main/java/com/raisetech/service/TaskService.java
@@ -33,6 +33,11 @@ public class TaskService {
         taskMapper.insertTask(task);
     }
     
+    // 完了フラグを未完了から完了に更新
+    public void updateToCompletedFlag(int taskId) {
+    	taskMapper.updateToCompletedFlag(taskId);
+    }
+    
     //登録済みタスクの一件削除処理
     public void deleteTask(int taskId){
         taskMapper.deleteTask(taskId);

--- a/src/main/java/com/raisetech/service/TaskService.java
+++ b/src/main/java/com/raisetech/service/TaskService.java
@@ -34,8 +34,8 @@ public class TaskService {
     }
     
     // 完了フラグを未完了から完了に更新
-    public void updateToCompletedFlag(int taskId) {
-    	taskMapper.updateToCompletedFlag(taskId);
+    public void updateTaskToComplete(int taskId) {
+    	taskMapper.updateTaskToComplete(taskId);
     }
     
     //登録済みタスクの一件削除処理

--- a/src/main/java/com/raisetech/service/TaskService.java
+++ b/src/main/java/com/raisetech/service/TaskService.java
@@ -34,8 +34,8 @@ public class TaskService {
     }
     
     // 完了フラグを未完了から完了に更新
-    public void updateTaskToComplete(int taskId) {
-    	taskMapper.updateTaskToComplete(taskId);
+    public void updateCompletedFlagToTrue(int taskId) {
+    	taskMapper.updateCompletedFlagToTrue(taskId);
     }
     
     //登録済みタスクの一件削除処理

--- a/src/main/resources/mapper/mysql/TaskMapper.xml
+++ b/src/main/resources/mapper/mysql/TaskMapper.xml
@@ -34,7 +34,7 @@
 			)	
 	</insert>
 	
-	<update id="updateTaskToComplete">
+	<update id="updateCompletedFlagToTrue">
 		UPDATE tasks
 		SET completed_flag = true
 		WHERE task_id = #{taskId}

--- a/src/main/resources/mapper/mysql/TaskMapper.xml
+++ b/src/main/resources/mapper/mysql/TaskMapper.xml
@@ -34,6 +34,12 @@
 			)	
 	</insert>
 	
+	<update id="updateToCompletedFlag">
+		UPDATE tasks
+		SET completed_flag = true
+		WHERE task_id = #{taskId}
+	</update>
+	
 	<delete id="deleteTask">
 		DELETE FROM
 			tasks

--- a/src/main/resources/mapper/mysql/TaskMapper.xml
+++ b/src/main/resources/mapper/mysql/TaskMapper.xml
@@ -34,7 +34,7 @@
 			)	
 	</insert>
 	
-	<update id="updateToCompletedFlag">
+	<update id="updateTaskToComplete">
 		UPDATE tasks
 		SET completed_flag = true
 		WHERE task_id = #{taskId}


### PR DESCRIPTION
完了フラグを未完了から完了に更新する処理を追加しました

メソッド名はupdateCompletedFlagToTrueとしました。
メソッド名の変遷は、
updateCompletedFlag(1) -> updateToCompletedFlag(2) -> updateTaskToComplete(3) -> updateCompletedFlagToTrue(4)です。

(1)カラム名のcompletedFlagを更新という意味。しかし、未完了に？完了に？どっちに更新するかわからない。
(2)完了フラグに更新という意味。「カラム名」と「完了のフラグ(trueのみ)」と二つの意味を持つためわかりづらい。
(3)タスクを完了に更新という意味。「タスクを完了に更新した」・・・・わかりづらい？？？
(4)completedFlagをTrueに更新したという意味。要件がわからない人にはわかりづらいとも思ったが、完了のフラグがTrueというのは、「完了した」とくみ取れると判断しました。

長々書いてしまいましたが、file changedの量は少ないので、確認お願いします！！笑